### PR TITLE
portend 3.2.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: aa9d40ab1f9e14bdb7d401f42210df35d017c9b97991baeb18568cedfb8c6489
 
 build:
-  noarch: python
+  skip: true  # [py<39]
   number: 0
   script: python -m pip install --no-deps --ignore-installed .
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: true  # [py<39]
   number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,18 +10,18 @@ source:
   sha256: aa9d40ab1f9e14bdb7d401f42210df35d017c9b97991baeb18568cedfb8c6489
 
 build:
-  skip: true  # [py<39]
   number: 0
+  skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
 
 requirements:
-  build:
-    - python >=3.6
+  host:
+    - python
     - pip
+    - setuptools >=77
     - setuptools_scm >=3.4.1
-
   run:
-    - python >=3.6
+    - python
     - tempora >=1.8
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ test:
   requires:
     - python
     - pip
-    - pytest
+    - pytest >=6,!= 8.1.*
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ test:
     - pytest
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - pytest -vv test_portend.py
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,13 @@
 {% set name = "portend" %}
-{% set version = "2.7.1" %}
-{% set bundle = "tar.gz" %}
-{% set hash_type = "sha256" %}
-{% set hash = "986ed9a278e64a87b5b5f4c21e61c25bebdce9919a92238d9c14c37a7416482b" %}
+{% set version = "3.2.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.{{ bundle }}
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
-  {{ hash_type }}: {{ hash }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: aa9d40ab1f9e14bdb7d401f42210df35d017c9b97991baeb18568cedfb8c6489
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,15 @@ requirements:
     - tempora >=1.8
 
 test:
+  source_files:
+    - test_portend.py
   imports:
     - portend
+  requires:
+    - pytest
+  commands:
+    - pip check
+    - pytest -vv test_portend.py
 
 about:
   home: https://github.com/jaraco/portend

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - pip
     - setuptools >=77
     - setuptools_scm >=3.4.1
+    - wheel
   run:
     - python
     - tempora >=1.8
@@ -30,6 +31,8 @@ test:
   imports:
     - portend
   requires:
+    - python
+    - pip
     - pytest
   commands:
     - pip check
@@ -42,6 +45,7 @@ about:
   license: MIT
   license_family: MIT
   summary: TCP port monitoring utilities
+  description: A simple library for managing the availability of ports.
   dev_url: https://github.com/jaraco/portend
   doc_url: https://portend.readthedocs.io
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,9 +41,10 @@ test:
 
 about:
   home: https://github.com/jaraco/portend
-  # license_file: No license or manifest - see https://github.com/jaraco/portend/issues/3
   license: MIT
   license_family: MIT
+  # While not included in the GH release, license file is included in the pypi release
+  license_file: LICENSE
   summary: TCP port monitoring utilities
   description: A simple library for managing the availability of ports.
   dev_url: https://github.com/jaraco/portend

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ about:
   license_family: MIT
   summary: TCP port monitoring utilities
   dev_url: https://github.com/jaraco/portend
-
+  doc_url: https://portend.readthedocs.io
 extra:
   recipe-maintainers:
     - pmlandwehr

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,8 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest -vv test_portend.py
+    # Freezes CI on linux platforms
+    - pytest -vv test_portend.py  # [not linux]
 
 about:
   home: https://github.com/jaraco/portend


### PR DESCRIPTION
portend 3.2.1 

**Destination channel:** Defaults

### Links

- [PKG-8583]
- dev_url:        https://github.com/jaraco/portend/tree/v3.2.1
- conda_forge:    https://github.com/conda-forge/portend-feedstock
- pypi:           https://pypi.org/project/portend/3.2.1
- pypi inspector: https://inspector.pypi.io/project/portend/3.2.1

### Explanation of changes:

- new version number


[PKG-8583]: https://anaconda.atlassian.net/browse/PKG-8583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ